### PR TITLE
feat: add emoji shortcode support (:smile: → 😄)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "markdown-docs",
-  "version": "1.2.15",
+  "version": "1.2.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-docs",
-      "version": "1.2.15",
+      "version": "1.2.25",
       "dependencies": {
         "js-yaml": "^4.1.0",
         "lexical": "^0.35.0",
         "mdast-util-directive": "^3.1.0",
         "mdast-util-frontmatter": "^2.0.1",
         "micromark-extension-frontmatter": "^2.0.0",
+        "node-emoji": "^2.2.0",
         "uuid": "^11.1.0",
         "yaml": "^2.8.1"
       },
@@ -909,6 +910,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
     "node_modules/@trivago/prettier-plugin-sort-imports": {
@@ -2629,6 +2642,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -3257,6 +3279,12 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emojilib": {
+      "version": "2.4.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/emojilib/-/emojilib-2.4.0.tgz",
+      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -6490,6 +6518,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-emoji": {
+      "version": "2.2.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/node-emoji/-/node-emoji-2.2.0.tgz",
+      "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.6.0",
+        "char-regex": "^1.0.2",
+        "emojilib": "^2.4.0",
+        "skin-tone": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -8115,6 +8158,18 @@
         "node": ">= 10"
       }
     },
+    "node_modules/skin-tone": {
+      "version": "2.0.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/skin-tone/-/skin-tone-2.0.0.tgz",
+      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+      "license": "MIT",
+      "dependencies": {
+        "unicode-emoji-modifier-base": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -8789,6 +8844,15 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/unicode-emoji-modifier-base": {
+      "version": "1.0.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/unist-util-is": {

--- a/package.json
+++ b/package.json
@@ -209,6 +209,7 @@
     "mdast-util-directive": "^3.1.0",
     "mdast-util-frontmatter": "^2.0.1",
     "micromark-extension-frontmatter": "^2.0.0",
+    "node-emoji": "^2.2.0",
     "uuid": "^11.1.0",
     "yaml": "^2.8.1"
   }

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -29,7 +29,7 @@ const extensionConfig = {
   },
   resolve: {
     // support reading TypeScript and JavaScript files
-    extensions: ['.ts', '.js'],
+    extensions: ['.ts', '.js', '.json'],
     alias: {
       '@': path.resolve(__dirname, './src'),
       '@webview': path.resolve(__dirname, './webview-ui/src')

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 
+import * as nodeEmoji from 'node-emoji';
 import * as vscode from 'vscode';
 
 import { logger } from './utils/logger';
@@ -619,14 +620,92 @@ function preprocessAngleBrackets(markdown: string): string {
 
 function postprocessAngleBrackets(markdown: string): string {
   // First clean up escaped underscores inside curly braces
-  const result = markdown.replace(/\{\{([^}]*)\}\}/g, (match, content) => {
+  let result = markdown.replace(/\{\{([^}]*)\}\}/g, (match, content) => {
     // Remove backslash escaping from underscores within curly braces
     const unescapedContent = (content as string).replace(/\\_/g, '_');
     return `{{${unescapedContent}}}`;
   });
 
   // Then remove backslash escaping from < characters (we no longer escape >)
-  return result.replace(/\\</g, '<');
+  result = result.replace(/\\</g, '<');
+
+  // Remove backslash escaping from emoji characters that MDXEditor may have escaped
+  result = result.replace(/\\([\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F1E0}-\u{1F1FF}\u{2600}-\u{27BF}\u{2B50}\u{2B55}\u{231A}-\u{23F3}\u{23E9}-\u{23EF}\u{25AA}-\u{25FE}\u{2702}-\u{27B0}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1FA70}-\u{1FAFF}\u{FE0F}\u{200D}\u{20E3}\u{E0020}-\u{E007F}])/gu, '$1');
+
+  // Convert emoji shortcodes (e.g., :smile: → 😄) to unicode
+  // Uses code-aware conversion to skip shortcodes inside code blocks and inline code
+  result = convertEmojiShortcodes(result);
+
+  return result;
+}
+
+/**
+ * Convert emoji shortcodes (e.g., :smile:, :rocket:) to unicode emoji characters.
+ * Respects code contexts — shortcodes inside inline code or fenced code blocks are left untouched.
+ *
+ * NOTE: A parallel implementation exists in webview-ui/src/utils/emojiShortcodes.ts
+ * for the webview build target. Keep both in sync when making changes.
+ */
+function convertEmojiShortcodes(markdown: string): string {
+  if (!markdown) {
+    return markdown;
+  }
+
+  const result: string[] = [];
+  let i = 0;
+
+  while (i < markdown.length) {
+    // Check for fenced code block (``` or ~~~)
+    if (
+      (markdown[i] === '`' && markdown.slice(i, i + 3) === '```') ||
+      (markdown[i] === '~' && markdown.slice(i, i + 3) === '~~~')
+    ) {
+      const fence = markdown.slice(i, i + 3);
+      const endIndex = markdown.indexOf('\n' + fence, i + 3);
+      if (endIndex !== -1) {
+        let closeEnd = endIndex + 1 + fence.length;
+        while (closeEnd < markdown.length && markdown[closeEnd] !== '\n') {
+          closeEnd++;
+        }
+        result.push(markdown.slice(i, closeEnd));
+        i = closeEnd;
+      } else {
+        result.push(markdown.slice(i));
+        i = markdown.length;
+      }
+      continue;
+    }
+
+    // Check for inline code (backtick)
+    if (markdown[i] === '`') {
+      const endIndex = markdown.indexOf('`', i + 1);
+      if (endIndex !== -1) {
+        result.push(markdown.slice(i, endIndex + 1));
+        i = endIndex + 1;
+      } else {
+        result.push(markdown.slice(i));
+        i = markdown.length;
+      }
+      continue;
+    }
+
+    // Regular text — collect until the next code boundary
+    let textEnd = i;
+    while (
+      textEnd < markdown.length &&
+      markdown[textEnd] !== '`' &&
+      !(markdown[textEnd] === '~' && markdown.slice(textEnd, textEnd + 3) === '~~~')
+    ) {
+      textEnd++;
+    }
+
+    // Apply emoji conversion to this text segment
+    const textSegment = markdown.slice(i, textEnd);
+    result.push(nodeEmoji.emojify(textSegment));
+    i = textEnd;
+  }
+
+  return result.join('');
 }
 
 export function activate(context: vscode.ExtensionContext): void {

--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -15,6 +15,7 @@
         "mdast-util-frontmatter": "^2.0.1",
         "mermaid": "^11.10.1",
         "micromark-extension-frontmatter": "^2.0.0",
+        "node-emoji": "^2.2.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "remark-frontmatter": "^5.0.0"
@@ -2207,6 +2208,18 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@stitches/core": {
       "version": "1.2.8",
       "license": "MIT"
@@ -3513,6 +3526,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "license": "MIT",
@@ -4662,6 +4684,12 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emojilib": {
+      "version": "2.4.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/emojilib/-/emojilib-2.4.0.tgz",
+      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -7293,6 +7321,21 @@
       "version": "1.1.0",
       "license": "ISC"
     },
+    "node_modules/node-emoji": {
+      "version": "2.2.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/node-emoji/-/node-emoji-2.2.0.tgz",
+      "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.6.0",
+        "char-regex": "^1.0.2",
+        "emojilib": "^2.4.0",
+        "skin-tone": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.3.1",
       "dev": true,
@@ -8620,6 +8663,18 @@
         "node": ">= 10"
       }
     },
+    "node_modules/skin-tone": {
+      "version": "2.0.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/skin-tone/-/skin-tone-2.0.0.tgz",
+      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+      "license": "MIT",
+      "dependencies": {
+        "unicode-emoji-modifier-base": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/sockjs": {
       "version": "0.3.24",
       "dev": true,
@@ -9108,6 +9163,15 @@
       "version": "7.10.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unicode-emoji-modifier-base": {
+      "version": "1.0.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/unidiff": {
       "version": "1.0.4",

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -19,6 +19,7 @@
     "mdast-util-frontmatter": "^2.0.1",
     "mermaid": "^11.10.1",
     "micromark-extension-frontmatter": "^2.0.0",
+    "node-emoji": "^2.2.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "remark-frontmatter": "^5.0.0"

--- a/webview-ui/rspack.config.js
+++ b/webview-ui/rspack.config.js
@@ -24,7 +24,7 @@ const webviewConfig = {
   
   resolve: {
     // support reading TypeScript and JavaScript files, plus JSX
-    extensions: ['.tsx', '.ts', '.jsx', '.js'],
+    extensions: ['.tsx', '.ts', '.jsx', '.js', '.json'],
     alias: {
       '@': path.resolve(__dirname, './src'),
       '@extension': path.resolve(__dirname, '../src')

--- a/webview-ui/src/components/plugins/emojiShortcodePlugin.tsx
+++ b/webview-ui/src/components/plugins/emojiShortcodePlugin.tsx
@@ -1,0 +1,70 @@
+/**
+ * MDXEditor/Lexical plugin that converts emoji shortcodes (e.g., :smile:) to unicode emoji
+ * inline as the user types. Uses Lexical's text node transform system so cursor position
+ * is preserved naturally.
+ */
+import { createRootEditorSubscription$, realmPlugin } from '@mdxeditor/editor';
+import { $getSelection, $isRangeSelection, TextNode } from 'lexical';
+
+import * as nodeEmoji from 'node-emoji';
+
+// Regex to match emoji shortcodes like :smile:, :rocket:, :+1:
+const EMOJI_SHORTCODE_REGEX = /:([a-zA-Z0-9_+\-]+):/g;
+
+/**
+ * Find and replace emoji shortcodes in text, returning replacement details
+ * so we can adjust cursor position correctly.
+ */
+function findEmojiReplacements(text: string): { newText: string; changed: boolean; offsetShift: number; lastReplacementEnd: number } {
+  let changed = false;
+  let offsetShift = 0;
+  let lastReplacementEnd = -1;
+
+  const newText = text.replace(EMOJI_SHORTCODE_REGEX, (match, name: string, matchOffset: number) => {
+    const emoji = nodeEmoji.get(name);
+    if (emoji && emoji !== match) {
+      changed = true;
+      // Track where this replacement ends in the NEW string
+      lastReplacementEnd = matchOffset + offsetShift + emoji.length;
+      // Track cumulative offset shift (emoji is shorter than shortcode)
+      offsetShift += emoji.length - match.length;
+      return emoji;
+    }
+    return match;
+  });
+
+  return { newText, changed, offsetShift, lastReplacementEnd };
+}
+
+/**
+ * MDXEditor realm plugin that registers a Lexical text node transform
+ * to convert emoji shortcodes to unicode characters as the user types.
+ */
+export const emojiShortcodePlugin = realmPlugin({
+  init(realm) {
+    realm.pub(createRootEditorSubscription$, (editor) => {
+      return editor.registerNodeTransform(TextNode, (textNode) => {
+        const text = textNode.getTextContent();
+        if (!text.includes(':')) return;
+
+        const { newText, changed, lastReplacementEnd } = findEmojiReplacements(text);
+        if (!changed) return;
+
+        // Get current selection before making changes
+        const selection = $getSelection();
+        const isSelected = $isRangeSelection(selection) &&
+          selection.anchor.key === textNode.getKey();
+
+        // Replace the text content
+        textNode.setTextContent(newText);
+
+        // Restore cursor position after the emoji
+        if (isSelected && lastReplacementEnd >= 0) {
+          // Place cursor right after the last replaced emoji
+          selection.anchor.set(textNode.getKey(), lastReplacementEnd, 'text');
+          selection.focus.set(textNode.getKey(), lastReplacementEnd, 'text');
+        }
+      });
+    });
+  },
+});

--- a/webview-ui/src/components/plugins/escapeCharPlugin.tsx
+++ b/webview-ui/src/components/plugins/escapeCharPlugin.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { convertEmojiShortcodes } from '@/utils/emojiShortcodes';
 
 // Simple and reliable approach: escape ALL angle brackets AND protect curly brace patterns
 // Since suppressHtmlProcessing doesn't work reliably, we'll escape everything
@@ -27,12 +28,17 @@ const isInCodeBlock = (text: string, position: number): boolean => {
 };
 
 // Main preprocessing function - escape ALL angle brackets AND protect curly braces, clean up unwanted escaping
+// Also converts emoji shortcodes (e.g., :smile: → 😄) to unicode emoji characters
 export const preprocessAngleBrackets = (markdown: string): string => {
   // First clean up any unwanted escaping from previous processing
   let cleanedMarkdown = markdown;
   cleanedMarkdown = cleanedMarkdown.replace(/\\\[/g, '[');
   cleanedMarkdown = cleanedMarkdown.replace(/\\\]/g, ']');
   cleanedMarkdown = cleanedMarkdown.replace(/\\\|/g, '|');
+
+  // Convert emoji shortcodes to unicode (e.g., :smile: → 😄)
+  // Done early so the editor renders actual emoji characters
+  cleanedMarkdown = convertEmojiShortcodes(cleanedMarkdown);
 
   // Then protect curly brace patterns
   const result = preprocessCurlyBraces(cleanedMarkdown);

--- a/webview-ui/src/hooks/usePlugins.tsx
+++ b/webview-ui/src/hooks/usePlugins.tsx
@@ -3,6 +3,7 @@ import { Toolbar } from '@/components/Toolbar';
 import { commentInsertionPlugin } from '@/components/plugins/commentInsertionPlugin';
 import { customSearchPlugin } from '@/components/plugins/customSearchPlugin';
 import { commentsPlugin } from '@/components/plugins/directives';
+import { emojiShortcodePlugin } from '@/components/plugins/emojiShortcodePlugin';
 import { frontmatterPlugin } from '@/components/plugins/frontmatter';
 import { DirectiveService } from '@/services/directive';
 import { CommentWithAnchor, FontFamily, WebviewMessage } from '@/types';
@@ -529,6 +530,7 @@ export const usePlugins = ({
       markdownShortcutPlugin(),
       customSearchPlugin({}),
       frontmatterPlugin(),
+      emojiShortcodePlugin(),
       diffSourcePluginFactory(),
       imagePluginFactory(),
       commentInsertionPluginFactory(),

--- a/webview-ui/src/utils/emojiShortcodes.ts
+++ b/webview-ui/src/utils/emojiShortcodes.ts
@@ -1,0 +1,78 @@
+import * as nodeEmoji from 'node-emoji';
+
+/**
+ * Convert emoji shortcodes (e.g., :smile:, :rocket:) to unicode emoji characters.
+ * Respects code contexts — shortcodes inside inline code (`...`) or fenced code blocks (```...```)
+ * are left untouched.
+ *
+ * Uses the same shortcode set as GitHub, Slack, and other popular tools via the `node-emoji` library.
+ *
+ * NOTE: A parallel implementation exists in src/extension.ts for the extension build target.
+ * Keep both in sync when making changes.
+ *
+ * @param markdown - The markdown string to process
+ * @returns The markdown with emoji shortcodes replaced by unicode emoji characters
+ */
+export const convertEmojiShortcodes = (markdown: string): string => {
+  if (!markdown) {
+    return markdown;
+  }
+
+  // Process the markdown while respecting code contexts.
+  // We split the text into segments: code blocks, inline code, and regular text.
+  // Only regular text segments get emoji shortcode conversion.
+  const result: string[] = [];
+  let i = 0;
+
+  while (i < markdown.length) {
+    // Check for fenced code block (``` or ~~~)
+    if (
+      (markdown[i] === '`' && markdown.slice(i, i + 3) === '```') ||
+      (markdown[i] === '~' && markdown.slice(i, i + 3) === '~~~')
+    ) {
+      const fence = markdown.slice(i, i + 3);
+      const endIndex = markdown.indexOf('\n' + fence, i + 3);
+      if (endIndex !== -1) {
+        // Find the end of the closing fence line
+        let closeEnd = endIndex + 1 + fence.length;
+        while (closeEnd < markdown.length && markdown[closeEnd] !== '\n') {
+          closeEnd++;
+        }
+        result.push(markdown.slice(i, closeEnd));
+        i = closeEnd;
+      } else {
+        // No closing fence found — treat rest as code block
+        result.push(markdown.slice(i));
+        i = markdown.length;
+      }
+      continue;
+    }
+
+    // Check for inline code (backtick)
+    if (markdown[i] === '`') {
+      const endIndex = markdown.indexOf('`', i + 1);
+      if (endIndex !== -1) {
+        result.push(markdown.slice(i, endIndex + 1));
+        i = endIndex + 1;
+      } else {
+        // No closing backtick — treat rest as-is
+        result.push(markdown.slice(i));
+        i = markdown.length;
+      }
+      continue;
+    }
+
+    // Regular text — collect until the next code boundary
+    let textEnd = i;
+    while (textEnd < markdown.length && markdown[textEnd] !== '`' && !(markdown[textEnd] === '~' && markdown.slice(textEnd, textEnd + 3) === '~~~')) {
+      textEnd++;
+    }
+
+    // Apply emoji conversion to this text segment
+    const textSegment = markdown.slice(i, textEnd);
+    result.push(nodeEmoji.emojify(textSegment));
+    i = textEnd;
+  }
+
+  return result.join('');
+};


### PR DESCRIPTION
Type emoji shortcodes like :smile:, :rocket:, :x: in the editor and they are automatically converted to unicode emoji characters (😄, 🚀, ❌).

Implementation:
- Lexical TextNode transform plugin for live inline conversion with cursor preservation as the user types in rich-text mode
- Extension-side postprocessing converts shortcodes on save and strips backslash escaping MDXEditor adds to emoji characters
- Webview-side preprocessing converts shortcodes when switching from source mode to rich-text mode
- Code-aware: shortcodes inside backticks and fenced code blocks are left untouched

Uses node-emoji (GitHub/Slack-compatible shortcode set).

New files:
- webview-ui/src/components/plugins/emojiShortcodePlugin.tsx
- webview-ui/src/utils/emojiShortcodes.ts