### PR TITLE
feat: support clicking local file links to open in VS Code

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,8 @@ interface WebviewMessage {
   bookViewWidth?: string;
   bookViewMargin?: string;
   isInteracting?: boolean;
+  url?: string;
+  relativePath?: string;
   settings?: {
     defaultFont: string;
     fontSize: number;
@@ -407,6 +409,44 @@ class MarkdownTextEditorProvider implements vscode.CustomTextEditorProvider {
               userInteractionRegistry.add(fileUri);
             } else {
               userInteractionRegistry.delete(fileUri);
+            }
+            break;
+          }
+
+          case 'resolveLink': {
+            if (message.relativePath) {
+              const workspaceFolders = vscode.workspace.workspaceFolders;
+              const workspaceRoot = workspaceFolders && workspaceFolders.length > 0
+                ? workspaceFolders[0].uri
+                : vscode.Uri.joinPath(document.uri, '..');
+              const documentDir = vscode.Uri.joinPath(document.uri, '..');
+
+              // Try resolving as a local file: workspace root first, then document-relative
+              const workspaceUri = vscode.Uri.joinPath(workspaceRoot, message.relativePath);
+              const documentUri = vscode.Uri.joinPath(documentDir, message.relativePath);
+
+              let opened = false;
+              try {
+                await vscode.workspace.fs.stat(workspaceUri);
+                this.outputChannel.appendLine(`Opening local file (workspace): ${workspaceUri.toString()}`);
+                await vscode.commands.executeCommand('vscode.open', workspaceUri);
+                opened = true;
+              } catch {
+                try {
+                  await vscode.workspace.fs.stat(documentUri);
+                  this.outputChannel.appendLine(`Opening local file (document-relative): ${documentUri.toString()}`);
+                  await vscode.commands.executeCommand('vscode.open', documentUri);
+                  opened = true;
+                } catch {
+                  // Not a local file
+                }
+              }
+
+              // If not found locally, open as external URL in browser
+              if (!opened && message.url) {
+                this.outputChannel.appendLine(`Opening external link: ${message.url}`);
+                await vscode.env.openExternal(vscode.Uri.parse(message.url));
+              }
             }
             break;
           }

--- a/webview-ui/src/components/MDXEditorWrapper.tsx
+++ b/webview-ui/src/components/MDXEditorWrapper.tsx
@@ -20,9 +20,9 @@ import {
   postContentSave,
   postDirtyState,
   postError,
-  postExternalLink,
   postGetFont,
   postReady,
+  postToExtension,
   postUserInteraction,
 } from '../utils/extensionMessaging';
 import { logger } from '../utils/logger';
@@ -224,39 +224,73 @@ export const MDXEditorWrapper: React.FC<MDXEditorWrapperProps> = ({
   }, []);
 
   // Handle link clicks in the editor
+  // Uses a capturing listener on document to intercept clicks before VS Code's
+  // webview navigation handler can see them.
   useEffect(() => {
     const handleLinkClick = (event: Event) => {
       const target = event.target as HTMLElement;
+      const mouseEvent = event as MouseEvent;
 
       // Check if clicked element is a link
       if (target.tagName === 'A' || target.closest('a')) {
         const link =
           target.tagName === 'A' ? (target as HTMLAnchorElement) : (target.closest('a') as HTMLAnchorElement);
-        const href = link?.getAttribute('href');
+        // Use .href property (resolved URL) to detect local files,
+        // fall back to getAttribute for raw value
+        const resolvedHref = link?.href || '';
+        const rawHref = link?.getAttribute('href') || '';
+        const href = resolvedHref || rawHref;
 
         if (!href) {
           return;
         }
 
-        (event as MouseEvent).preventDefault();
-
         // Handle internal anchor links (e.g., #heading)
-        if (href.startsWith('#')) {
-          const headingId = href.substring(1);
+        if (rawHref.startsWith('#')) {
+          mouseEvent.preventDefault();
+          mouseEvent.stopImmediatePropagation();
+          const headingId = rawHref.substring(1);
           handleHeadingNavigation(headingId);
+          return;
         }
-        // Handle external links
-        else if (href.startsWith('http://') || href.startsWith('https://')) {
-          postExternalLink(href);
+
+        // All non-anchor links: try to resolve as a local file first.
+        // Lexical's formatUrl() prepends "https://" to relative paths like
+        // "people/file.md", making them "https://people/file.md".
+        // Instead of heuristic detection, we send the URL to the extension
+        // which tries to resolve it locally — if the file doesn't exist,
+        // it falls back to opening in the browser.
+        if (href.startsWith('http://') || href.startsWith('https://')) {
+          mouseEvent.preventDefault();
+          mouseEvent.stopImmediatePropagation();
+          mouseEvent.stopPropagation();
+          // Strip the https:// prefix and trailing slash to recover the original relative path
+          const strippedPath = href.replace(/^https?:\/\//, '').replace(/\/$/, '');
+          postToExtension({
+            command: 'resolveLink',
+            relativePath: strippedPath,
+            url: href,
+          });
+          return;
+        }
+
+        // Handle relative file links directly (without http scheme)
+        if (rawHref) {
+          mouseEvent.preventDefault();
+          mouseEvent.stopImmediatePropagation();
+          mouseEvent.stopPropagation();
+          postToExtension({
+            command: 'resolveLink',
+            relativePath: rawHref,
+            url: rawHref,
+          });
         }
       }
     };
 
-    const editorContainer = document.querySelector('.mdxeditor-root-contenteditable');
-    if (editorContainer) {
-      editorContainer.addEventListener('click', handleLinkClick);
-      return () => editorContainer.removeEventListener('click', handleLinkClick);
-    }
+    // Use capturing phase (true) to intercept before VS Code's webview handler
+    document.addEventListener('click', handleLinkClick, true);
+    return () => document.removeEventListener('click', handleLinkClick, true);
   }, [handleHeadingNavigation]);
 
   // Load saved font preference from VS Code settings on mount and signal ready

--- a/webview-ui/src/types.ts
+++ b/webview-ui/src/types.ts
@@ -50,6 +50,7 @@ export interface WebviewMessage {
   bookViewMargin?: string;
   isInteracting?: boolean;
   url?: string;
+  relativePath?: string;
   settings?: EditorSettings;
   editorConfig?: { wordWrap: string };
   uri?: string;


### PR DESCRIPTION
Relative markdown links like [text](people/file.md) are mangled by Lexical's formatUrl() which prepends https:// to paths without a protocol, turning them into pseudo-URLs like https://people/file.md. Previously these were either ignored or opened in the browser.

This change adds a resolveLink message handler that:
1. Strips the https:// prefix and trailing slash to recover the original relative path
2. Tries to resolve the path against the workspace root
3. Falls back to resolving relative to the current document's directory
4. If the file doesn't exist locally, opens the original URL in the browser as an external link

The webview click handler uses a capturing-phase listener on document to intercept link clicks before VS Code's webview navigation handler, preventing the 'open external website' confirmation dialog.

Additional changes:
- Added resolveLink command to extension message handler
- Added postToExtension import to MDXEditorWrapper
- Added postOpenLocalFile utility function
- Added relativePath and url fields to WebviewMessage interface